### PR TITLE
fix(mcp/tests): make test suite build standalone

### DIFF
--- a/vice/src/mcp/tests/test_mcp_tools.c
+++ b/vice/src/mcp/tests/test_mcp_tools.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 #include <sys/stat.h>

--- a/vice/src/mcp/tests/vice_stubs.c
+++ b/vice/src/mcp/tests/vice_stubs.c
@@ -1164,3 +1164,36 @@ void mainlock_release(void)
 {
     /* No-op in test environment */
 }
+
+/* archdep stubs */
+char *archdep_tmpnam(void)
+{
+    return strdup("/tmp/vice_mcp_test_tmpfile");
+}
+
+typedef struct archdep_dir_s archdep_dir_t;
+
+archdep_dir_t *archdep_opendir(const char *path, int mode)
+{
+    (void)path;
+    (void)mode;
+    return NULL;
+}
+
+const char *archdep_readdir(archdep_dir_t *dir)
+{
+    (void)dir;
+    return NULL;
+}
+
+void archdep_closedir(archdep_dir_t *dir)
+{
+    (void)dir;
+}
+
+/* Keyboard buffer stub */
+int kbdbuf_feed(const char *s)
+{
+    (void)s;
+    return 0;
+}


### PR DESCRIPTION
## Summary

Two small issues kept `src/mcp/tests` from building/linking on a fresh checkout. With both fixed the suite builds cleanly and all 314 tests pass.

### 1. Missing `<stdint.h>` in `test_mcp_tools.c`

The file uses `uint8_t` / `uint16_t` (e.g. line 4038's `extern void test_snapshot_memory_set_byte(uint16_t addr, uint8_t value);` and line 7960's `uint8_t d011 = ...`) but doesn't include `<stdint.h>`. Adding it fixes compilation.

### 2. Missing stubs in `vice_stubs.c`

After linking `libmcp.a` from a `--enable-mcp-server` build, the test binary fails with undefined references to:

- `archdep_tmpnam` — pulled in by `mcp_tools_display.c:137` (screenshot tempfile)
- `archdep_opendir` / `archdep_readdir` / `archdep_closedir` — pulled in by `mcp_tools_snapshot.c:302-367` (snapshot directory listing)
- `kbdbuf_feed` — pulled in by `mcp_tools_input.c:183` (`keyboard.petscii`)

Added minimal no-op stubs so the tests link without pulling in the rest of VICE.

## Verification

```
$ cd vice/build && ../configure --enable-mcp-server --enable-gtk3ui --disable-pdf-docs
$ make -j$(nproc)              # libmcp.a builds
$ cd ../src/mcp/tests && make test
...
=== Test Results ===
Tests run:    314
Tests passed: 314
Tests failed: 0

SUCCESS: All tests passed
```

## Test plan

- [x] Tests build from a clean checkout against a fresh `libmcp.a`
- [x] All 314 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)