### PR TITLE
Revert upstream sync on main

### DIFF
--- a/vice/src/arch/gtk3/uicompiletimefeatures.c
+++ b/vice/src/arch/gtk3/uicompiletimefeatures.c
@@ -166,10 +166,9 @@ static GtkWidget *create_content_widget(void)
     gtk_tree_sortable_set_sort_func(sortable, COL_ISDEFINED, sort_symbol_func,
             GINT_TO_POINTER(COL_ISDEFINED), NULL);
     /* set default sort order */
-#if 0 /* do not sort by default */
     gtk_tree_sortable_set_sort_column_id(sortable, COL_SYMBOL,
-             GTK_SORT_ASCENDING);
-#endif
+            GTK_SORT_ASCENDING);
+
     /* create view */
     view =  gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
     gtk_tree_view_set_headers_clickable(GTK_TREE_VIEW(view), TRUE);

--- a/vice/src/c64/c64iec.c
+++ b/vice/src/c64/c64iec.c
@@ -149,7 +149,6 @@ void iec_drive_write(uint8_t data, unsigned int dnr)
     iec_update_ports();
 }
 
-/* This function must have no side effects */
 uint8_t iec_drive_read(unsigned int dnr)
 {
     return iecbus.drv_port;

--- a/vice/src/c64/c64parallel.c
+++ b/vice/src/c64/c64parallel.c
@@ -220,9 +220,6 @@ void parallel_cable_drive_write(int type, uint8_t data, int handshake, unsigned 
     }
 }
 
-/*
- * This function must have no side effects if handshake is false.
- */
 uint8_t parallel_cable_drive_read(int type, int handshake)
 {
     int port;

--- a/vice/src/c64dtv/c64dtviec.c
+++ b/vice/src/c64dtv/c64dtviec.c
@@ -74,7 +74,6 @@ void iec_drive_write(uint8_t data, unsigned int dnr)
     iec_update_ports();
 }
 
-/* This function must have no side effects */
 uint8_t iec_drive_read(unsigned int dnr)
 {
     return iecbus.drv_port;

--- a/vice/src/cbm2/cbm2iec.c
+++ b/vice/src/cbm2/cbm2iec.c
@@ -55,7 +55,6 @@ iecbus_t *iecbus_drive_port(void)
     return NULL;
 }
 
-/* This function must have no side effects */
 uint8_t iec_drive_read(unsigned int dnr)
 {
     /* FIXME: unused */

--- a/vice/src/core/viacore.c
+++ b/vice/src/core/viacore.c
@@ -451,7 +451,7 @@ void viacore_signal(via_context_t *via_context, int line, int edge)
                 update_myviairq(via_context);
 #ifdef MYVIA_NEED_LATCHING
                 if (IS_PA_INPUT_LATCH()) {
-                    via_context->ila = (via_context->read_pra)(via_context, VIA_PRA, false);
+                    via_context->ila = (via_context->read_pra)(via_context, VIA_PRA);
                 }
 #endif
             }
@@ -870,7 +870,7 @@ void viacore_store(via_context_t *via_context, uint16_t addr, uint8_t byte)
             if ((!(via_context->via[addr] & VIA_ACR_PA_LATCH)) &&
                                     (byte & VIA_ACR_PA_LATCH)) {
                 if (via_context->ifr & VIA_IM_CA1) {
-                    via_context->ila = (via_context->read_pra)(via_context, addr, false);
+                    via_context->ila = (via_context->read_pra)(via_context, addr);
                 }
             }
             /* switch on port B latching, same as for port A */
@@ -1111,7 +1111,7 @@ uint8_t viacore_read_(via_context_t *via_context, uint16_t addr)
             } else
 #endif
             {
-                byte = (via_context->read_pra)(via_context, addr, false);
+                byte = (via_context->read_pra)(via_context, addr);
                 /*
                  * Currently the latch is transparent, so there is no need
                  * to store the byte into it. That will happen next time
@@ -1143,7 +1143,7 @@ uint8_t viacore_read_(via_context_t *via_context, uint16_t addr)
             } else
 #endif
             {
-                byte = (via_context->read_prb)(via_context, false);
+                byte = (via_context->read_prb)(via_context);
                 /* Same comment about transparent latch as for PA */
             }
             byte = (byte & ~(via_context->via[VIA_DDRB]))
@@ -1225,7 +1225,7 @@ uint8_t viacore_peek(via_context_t *via_context, uint16_t addr)
         case VIA_PRA_NHS: /* port A, no handshake */
             {
                 uint8_t byte;
-                /* WARNING: this reads the voltage of the output pins, not
+                /* WARNING: this pin reads the voltage of the output pins, not
                 the ORA value as the other port. Value read might be different
                 from what is expected due to excessive load. */
 #ifdef MYVIA_NEED_LATCHING
@@ -1234,7 +1234,8 @@ uint8_t viacore_peek(via_context_t *via_context, uint16_t addr)
                 } else
 #endif
                 {
-                    byte = (via_context->read_pra)(via_context, addr, true);
+                    /* FIXME: side effects ? */
+                    byte = (via_context->read_pra)(via_context, addr);
                 }
                 return byte;
             }
@@ -1248,7 +1249,8 @@ uint8_t viacore_peek(via_context_t *via_context, uint16_t addr)
                 } else
 #endif
                 {
-                    byte = (via_context->read_prb)(via_context, true);
+                    /* FIXME: side effects ? */
+                    byte = (via_context->read_prb)(via_context);
                 }
                 byte = (byte & ~(via_context->via[VIA_DDRB]))
                        | (via_context->via[VIA_PRB] & via_context->via[VIA_DDRB]);

--- a/vice/src/drive/iec/cmdhd.c
+++ b/vice/src/drive/iec/cmdhd.c
@@ -805,19 +805,17 @@ static void store_pra9(via_context_t *via_context, uint8_t byte, uint8_t oldpa,
     }
 }
 
-static uint8_t read_pra9(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra9(via_context_t *via_context, uint16_t addr)
 {
     cmdhd_context_t *hd = (cmdhd_context_t *)via_context->context;
     scsi_context_t *scsi = (scsi_context_t*)(hd->scsi);
     uint8_t byte;
 
     byte = scsi_get_bus(scsi);
-    if (!peek_only) {
-        if (scsi->state != SCSI_STATE_BUSFREE && (addr & 0xf) == VIA_PRA) {
-            scsi_process_ack(scsi);
-        } else {
-            scsi_process_noack(scsi);
-        }
+    if (scsi->state!=SCSI_STATE_BUSFREE && ((addr & 0xf) == VIA_PRA) ) {
+        scsi_process_ack(scsi);
+    } else {
+        scsi_process_noack(scsi);
     }
     return byte;
 }
@@ -835,21 +833,18 @@ static void store_prb9(via_context_t *via_context, uint8_t byte, uint8_t p_oldpb
         scsi->sel, scsi->bsyo, byte, scsi->rst));
 }
 
-static uint8_t read_prb9(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb9(via_context_t *via_context)
 {
     cmdhd_context_t *hd = (cmdhd_context_t *)via_context->context;
     scsi_context_t *scsi = (scsi_context_t*)(hd->scsi);
     uint8_t temp, state;
 
-    if (!peek_only) {
-        scsi_process_noack(scsi);
-    }
-
+    scsi_process_noack(scsi);
     IDBG((LOG, "CMDHD: rprb9: SEL=%d BSY=%d REQ=%d", scsi->sel, scsi->bsyo, scsi->req));
     if ( (via_context->via[VIA_PCR] & 0xf0) == 0xf0 ) {
-        temp = (scsi->sel) & (scsi->bsyo);
+        temp=(scsi->sel) & (scsi->bsyo);
     } else {
-        temp = (!scsi->sel) & (scsi->bsyo);
+        temp=(!scsi->sel) & (scsi->bsyo);
     }
 
     /* mask scsi state to cmd specific pld value */
@@ -881,7 +876,7 @@ static uint8_t read_prb9(via_context_t *via_context, bool peek_only)
         (hd->scsi_dir << 3) | (state & 7);
 }
 
-static uint8_t read_prb10(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb10(via_context_t *via_context)
 {
     uint8_t byte;
     drivevia_context_t *viap;
@@ -991,7 +986,7 @@ static void reset(via_context_t *via_context)
 {
 }
 
-static uint8_t read_pra10(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra10(via_context_t *via_context, uint16_t addr)
 {
     return 255;
 }

--- a/vice/src/drive/iec/via1d1541.c
+++ b/vice/src/drive/iec/via1d1541.c
@@ -287,11 +287,10 @@ static void reset(via_context_t *via_context)
 {
 }
 
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     uint8_t byte;
     drivevia1_context_t *via1p;
-    bool handshake;
 
     via1p = (drivevia1_context_t *)(via_context->prv);
 
@@ -299,10 +298,7 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
         || via1p->diskunit->type == DRIVE_TYPE_1571
         || via1p->diskunit->type == DRIVE_TYPE_1571CR) {
         uint8_t tmp;
-
-        if (!peek_only) {
-            rotation_rotate_disk(via1p->drive);
-        }
+        rotation_rotate_disk(via1p->drive);
         tmp = (via1p->drive->byte_ready_level ? 0 : 0x80)
               | (via1p->drive->current_half_track == 2 ? 0 : 1);
         return (tmp & ~(via_context->via[VIA_DDRA]))
@@ -313,13 +309,8 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
         case DRIVE_PC_STANDARD:
         case DRIVE_PC_21SEC_BACKUP:
         case DRIVE_PC_FORMEL64:
-            handshake = peek_only ? false :
-                        (((addr == VIA_PRA) &&
-                          (via_context->via[VIA_PCR] & 0xe) == 0xa)) ? true :
-                        false;
-
             byte = parallel_cable_drive_read(via1p->diskunit->parallel_cable,
-                                             handshake);
+                                             (((addr == VIA_PRA) && (via_context->via[VIA_PCR] & 0xe) == 0xa)) ? 1 : 0);
             break;
         default:
             byte = ((via_context->via[VIA_PRA] & via_context->via[VIA_DDRA])
@@ -343,7 +334,7 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
    IN mask:     1110 0101   0xe5
    OUT mask:    0001 1010   0x1a
 */
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
     uint8_t driveid;

--- a/vice/src/drive/iec/via4000.c
+++ b/vice/src/drive/iec/via4000.c
@@ -230,7 +230,7 @@ static void reset(via_context_t *via_context)
 {
 }
 
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     uint8_t byte;
     drivevia_context_t *viap;
@@ -252,7 +252,7 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
     return byte;
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
     drivevia_context_t *viap;

--- a/vice/src/drive/iecieee/via2d.c
+++ b/vice/src/drive/iecieee/via2d.c
@@ -460,21 +460,17 @@ static void reset(via_context_t *via_context)
  * pre-PLA hardware, shows a 74LS164 (8-Bit Serial In/Parallel Out Shift Register)
  * and it would not be latched. SOE indeed affects BYTE READY.
  */
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only) {
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr) {
     /* GCR data port */
     uint8_t byte;
     drivevia2_context_t *via2p;
 
     via2p = (drivevia2_context_t *)(via_context->prv);
 
-    if (!peek_only) {
-        /* IF: add bus read delay */
-        via2p->drive->req_ref_cycles = BUS_READ_DELAY;
+    /* IF: add bus read delay */
+    via2p->drive->req_ref_cycles = BUS_READ_DELAY;
 
-        rotation_byte_read(via2p->drive);
-
-        via2p->drive->byte_ready_level = 0;
-    }
+    rotation_byte_read(via2p->drive);
 
     byte = ((via2p->drive->GCR_read & ~(via_context->via[VIA_DDRA]))
            | (via_context->via[VIA_PRA] & via_context->via[VIA_DDRA]));
@@ -482,41 +478,35 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
     printf("(%u)%02x", via2p->drive->GCR_head_offset/8, via2p->drive->GCR_read);
     if (byte != via2p->drive->GCR_read) printf("[%02x]", byte);
 #endif
+    via2p->drive->byte_ready_level = 0;
 
     return byte;
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
-    uint8_t byte, wp;
+    uint8_t byte;
     drivevia2_context_t *via2p;
 
     via2p = (drivevia2_context_t *)(via_context->prv);
 
-    if (peek_only) {
-        wp = via2p->drive->read_only ? 0x0 : 0x10;
-    } else {
-        /* IF: add bus read delay */
-        via2p->drive->req_ref_cycles = BUS_READ_DELAY;
+    /* IF: add bus read delay */
+    via2p->drive->req_ref_cycles = BUS_READ_DELAY;
 
-        rotation_rotate_disk(via2p->drive);
-
-        wp = drive_writeprotect_sense(via2p->drive);
-
-        /*
-         * See comments about port A latching at read_pra();
-         * clearing byte_ready_level here may be wrong.
-         */
-        via2p->drive->byte_ready_level = 0;
-    }
-
+    rotation_rotate_disk(via2p->drive);
     byte = ((rotation_sync_found(via2p->drive)
-           | wp
+           | drive_writeprotect_sense(via2p->drive)
            | 0x6f) /* output bits read 1 if used as input */
            & ~(via_context->via[VIA_DDRB]))
            | (via_context->via[VIA_PRB] & via_context->via[VIA_DDRB]);
 
     DBG(("read_prb %02x pb:%02x ddr:%02x",byte,via_context->via[VIA_PRB],via_context->via[VIA_DDRB]));
+
+    /*
+     * See comments about port A latching at read_pra();
+     * clearing byte_ready_level here may be wrong.
+     */
+    via2p->drive->byte_ready_level = 0;
 
     return byte;
 }

--- a/vice/src/drive/ieee/via1d2031.c
+++ b/vice/src/drive/ieee/via1d2031.c
@@ -249,7 +249,7 @@ static void reset(via_context_t *via_context)
     parieee_is_out = 1;
 }
 
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     uint8_t byte;
     drivevia1_context_t *via1p;
@@ -262,7 +262,7 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
            | (via_context->via[VIA_PRA] & via_context->via[VIA_DDRA]);
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
     drivevia1_context_t *via1p;

--- a/vice/src/pet/petiec.c
+++ b/vice/src/pet/petiec.c
@@ -55,7 +55,6 @@ iecbus_t *iecbus_drive_port(void)
     return NULL;
 }
 
-/* This function must have no side effects */
 uint8_t iec_drive_read(unsigned int dnr)
 {
     /* FIXME: unused */

--- a/vice/src/pet/petvia.c
+++ b/vice/src/pet/petvia.c
@@ -211,14 +211,11 @@ static void reset(via_context_t *via_context)
     store_userport_pa2(1);
 }
 
-inline static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+inline static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     uint8_t byte = 0xff;
 
-    /* Reading from the userport might not be peek-safe */
-    if (!peek_only) {
-        byte = read_userport_pbx(byte);
-    }
+    byte = read_userport_pbx(byte);
 
     /* joystick always pulls low, even if high output, so no
        masking with DDRA */
@@ -227,13 +224,11 @@ inline static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool p
     return byte;
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
 
-    if (!peek_only) {
-        drive_catch_up_hook(maincpu_clk);
-    }
+    drive_catch_up_hook(maincpu_clk);
 
     /* read parallel IEC interface line states */
     byte = 255

--- a/vice/src/plus4/plus4iec.c
+++ b/vice/src/plus4/plus4iec.c
@@ -68,7 +68,6 @@ void iec_drive_write(uint8_t data, unsigned int dnr)
     iec_update_ports();
 }
 
-/* This function must have no side effects */
 uint8_t iec_drive_read(unsigned int dnr)
 {
     return iecbus.drv_port;

--- a/vice/src/plus4/plus4parallel.c
+++ b/vice/src/plus4/plus4parallel.c
@@ -62,9 +62,6 @@ void parallel_cable_drive_write(int port, uint8_t data, int handshake, unsigned 
     parallel_cable_drive_value[dnr] = data;
 }
 
-/*
- * This function must have no side effects if handshake is false.
- */
 uint8_t parallel_cable_drive_read(int type, int handshake)
 {
     return parallel_cable_cpu_value & parallel_cable_drive_value[0] & parallel_cable_drive_value[1];

--- a/vice/src/via.h
+++ b/vice/src/via.h
@@ -213,8 +213,8 @@ typedef struct via_context_s {
     void (*store_sr)(struct via_context_s *, uint8_t);
     void (*sr_underflow)(struct via_context_s *);
     void (*store_t2l)(struct via_context_s *, uint8_t);
-    uint8_t (*read_pra)(struct via_context_s *, uint16_t, bool);
-    uint8_t (*read_prb)(struct via_context_s *, bool);
+    uint8_t (*read_pra)(struct via_context_s *, uint16_t);
+    uint8_t (*read_prb)(struct via_context_s *);
     void (*set_int)(struct via_context_s *, unsigned int, int, CLOCK);
     void (*restore_int)(struct via_context_s *, unsigned int, int);
     void (*set_ca2)(struct via_context_s *, int state);

--- a/vice/src/vic20/vic20iec.c
+++ b/vice/src/vic20/vic20iec.c
@@ -117,7 +117,6 @@ void iec_drive_write(uint8_t data, unsigned int dnr)
     resolve_bus_signals();
 }
 
-/* This function must have no side effects */
 uint8_t iec_drive_read(unsigned int dnr)
 {
     uint8_t drive_bus_val;
@@ -141,18 +140,13 @@ uint8_t iec_drive_read(unsigned int dnr)
 
 /* These two routines are called for VIA1 Port A. */
 
-uint8_t iec_pa_peek(void)
-{
-    cpu_bus_val = (bus_data << 1) | bus_clock | (NOT(bus_atn) << 7);
-
-    return cpu_bus_val;
-}
-
 uint8_t iec_pa_read(void)
 {
     drive_catch_up_hook(maincpu_clk);
 
-    return iec_pa_peek();
+    cpu_bus_val = (bus_data << 1) | bus_clock | (NOT(bus_atn) << 7);
+
+    return cpu_bus_val;
 }
 
 /* NOTE: when adding drives, do the equivalent change in src/iecbus/iecbus.c */

--- a/vice/src/vic20/vic20iec.h
+++ b/vice/src/vic20/vic20iec.h
@@ -32,7 +32,6 @@
 #include "types.h"
 
 void vic20iec_init(void);
-uint8_t iec_pa_peek(void);
 uint8_t iec_pa_read(void);
 void iec_pa_write(uint8_t data);
 void iec_pcr_write(uint8_t data);

--- a/vice/src/vic20/vic20ieeevia1.c
+++ b/vice/src/vic20/vic20ieeevia1.c
@@ -134,18 +134,16 @@ static uint8_t store_pcr(via_context_t *via_context, uint8_t byte, uint16_t addr
     return byte;
 }
 
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     return 0xff;
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
 
-    if (!peek_only) {
-        drive_catch_up_hook(maincpu_clk);
-    }
+    drive_catch_up_hook(maincpu_clk);
 
     byte = 255
            - (parallel_atn ? 0x80 : 0)

--- a/vice/src/vic20/vic20ieeevia2.c
+++ b/vice/src/vic20/vic20ieeevia2.c
@@ -143,20 +143,18 @@ static uint8_t store_pcr(via_context_t *via_context, uint8_t byte, uint16_t addr
     return byte;
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
 
-    if (!peek_only) {
-        drive_catch_up_hook(maincpu_clk);
-    }
+    drive_catch_up_hook(maincpu_clk);
 
     byte = (parallel_bus & ~(via_context->via[VIA_DDRB]))
            | (via_context->via[VIA_PRB] & via_context->via[VIA_DDRB]);
     return byte;
 }
 
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     return 0xff;
 }

--- a/vice/src/vic20/vic20via1.c
+++ b/vice/src/vic20/vic20via1.c
@@ -218,10 +218,10 @@ inline static void store_t2l(via_context_t *via_context, uint8_t byte)
 {
 }
 
-inline static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+inline static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
-    uint8_t byte, pa;
-    uint8_t joy_bits = 0xff;
+    uint8_t byte;
+    uint8_t joy_bits;
 
     /*
         Port A is connected this way:
@@ -247,24 +247,17 @@ inline static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool p
 
     /* We assume `iec_pa_read()' returns the non-IEC bits
        as zeroes. */
-    if (peek_only) {
-        pa = iec_pa_peek();
-    } else {
-        pa = iec_pa_read();
-    }
     byte = ((via_context->via[VIA_PRA] & via_context->via[VIA_DDRA])
-            | ((pa | joy_bits) & ~(via_context->via[VIA_DDRA])));
+            | ((iec_pa_read() | joy_bits) & ~(via_context->via[VIA_DDRA])));
     return byte;
 }
 
-inline static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+inline static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte = 0xff;
     byte = via_context->via[VIA_PRB] | ~(via_context->via[VIA_DDRB]);
 
-    if (!peek_only) {
-        byte = read_userport_pbx(byte);
-    }
+    byte = read_userport_pbx(byte);
 
     return byte;
 }

--- a/vice/src/vic20/vic20via2.c
+++ b/vice/src/vic20/vic20via2.c
@@ -170,13 +170,13 @@ static uint8_t store_pcr(via_context_t *via_context, uint8_t byte, uint16_t addr
               3 - cassette write
 */
 
-static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_only)
+static uint8_t read_pra(via_context_t *via_context, uint16_t addr)
 {
     uint8_t byte;
     /* FIXME: not 100% sure about this... */
     uint8_t val = ~(via_context->via[VIA_DDRA]);
     uint8_t msk = via_context->oldpb;
-    uint8_t joy = peek_only ? 0 : ~read_joyport_dig(JOYPORT_1);
+    uint8_t joy = ~read_joyport_dig(JOYPORT_1);
     int i;
 
     /* Bit 7 is mapped to the right direction of the joystick (bit
@@ -195,7 +195,7 @@ static uint8_t read_pra(via_context_t *via_context, uint16_t addr, bool peek_onl
     return byte;
 }
 
-static uint8_t read_prb(via_context_t *via_context, bool peek_only)
+static uint8_t read_prb(via_context_t *via_context)
 {
     uint8_t byte;
     /* FIXME: not 100% sure about this... */

--- a/vice/src/vicefeatures.c
+++ b/vice/src/vicefeatures.c
@@ -49,27 +49,20 @@ static const feature_list_t featurelist[] = {
 #else
         0 },
 #endif
-/* Gtk3UI debugging support */
-    { "HAVE_DEBUG_GTK3UI", "Enable debugging messages in the Gtk3 UI.",
-#ifndef HAVE_DEBUG_GTK3UI
-        0 },
-#else
-        1 },
-#endif
-
- /* (all) */
-    { "HAVE_EXPERIMENTAL_DEVICES", "Enable experimental devices",
-#ifndef HAVE_EXPERIMENTAL_DEVICES
-        0 },
-#else
-        1 },
-#endif
 /* (all) */
-    { "HAVE_X64_IMAGE", "Support for X64 image files (deprecated)",
-#ifndef HAVE_X64_IMAGE
-      0 },
+    { "FEATURE_CPUMEMHISTORY", "Enable the memmap/chis feature in the monitor.",
+#ifndef FEATURE_CPUMEMHISTORY
+        0 },
 #else
-      1 },
+        1 },
+#endif
+#ifdef MACOS_COMPILE /* (osx) */
+    { "HAS_HIDMGR", "Enable Mac IOHIDManager Joystick driver.",
+#ifndef HAS_HIDMGR
+        0 },
+#else
+        1 },
+#endif
 #endif
 #ifdef UNIX_COMPILE /* (unix) */
     { "HAS_USB_JOYSTICK", "Enable emulation for USB joysticks. (deprecated)",
@@ -79,43 +72,56 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
-
-/* (all) */
-    { "FEATURE_CPUMEMHISTORY", "Enable the memmap/chis feature in the monitor.",
-#ifndef FEATURE_CPUMEMHISTORY
+#if defined(MACOS_COMPILE) /* (osx) */
+    { "HAVE_AUDIO_UNIT", "Enable AudioUnit support.",
+#ifndef HAVE_AUDIO_UNIT
         0 },
 #else
         1 },
 #endif
-/* (all) */
-    { "USE_VICE_THREAD", "UI and emu each on different threads.",
-#  ifndef USE_VICE_THREAD
-        0 },
-#  else
-        1 },
-#  endif
-#if defined(UNIX_COMPILE) && !defined(MACOS_COMPILE)
-    { "INSTALL_DESKTOP_FILES", "Install XDG desktop files and icons.",
-#  ifndef INSTALL_DESKTOP_FILES
-        0 },
-#  else
-        1 },
-#  endif
 #endif
-/*
- * Used in Gtk3 for Unix. Gtk3 can also use fontconfig as a backend on MacOS
- * and Windows.
- */
-    { "HAVE_FONTCONFIG", "Support dynamic font loading via Fontconfig.",
-#ifndef HAVE_FONTCONFIG
+#if defined(BEOS_COMPILE) || defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (beos/unix/windows) */
+    { "HAVE_CATWEASELMKIII", "Support for Catweasel MKIII.",
+#ifndef HAVE_CATWEASELMKIII
         0 },
 #else
         1 },
 #endif
+#endif
 
+#ifdef WINDOWS_COMPILE /* (windows) */
+    { "HAVE_DINPUT", "Use the DirectInput joystick driver",
+#ifndef HAVE_DINPUT
+        0 },
+#else
+        1 },
+#endif
+#endif
 #if defined(UNIX_COMPILE) || defined(MACOS_COMPILE) || defined(WINDOWS_COMPILE) /* (unix/osx/windows) */
     { "HAVE_DYNLIB_SUPPORT", "Support dynamic library loading.",
 #ifndef HAVE_DYNLIB_SUPPORT
+        0 },
+#else
+        1 },
+#endif
+#endif
+ /* (all) */
+    { "HAVE_EXPERIMENTAL_DEVICES", "Enable experimental devices",
+#ifndef HAVE_EXPERIMENTAL_DEVICES
+        0 },
+#else
+        1 },
+#endif
+ /* (all) */
+    { "HAVE_GIF", "Use the GIF or UNGIF library",
+#ifndef HAVE_GIF
+        0 },
+#else
+        1 },
+#endif
+#if defined(BEOS_COMPILE) || defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (beos/unix/windows) */
+    { "HAVE_HARDSID", "Support for HardSID.",
+#ifndef HAVE_HARDSID
         0 },
 #else
         1 },
@@ -130,22 +136,19 @@ static const feature_list_t featurelist[] = {
 #endif
 #endif
 /* (all) */
-    { "HAVE_NANOSLEEP", "Use nanosleep instead of usleep",
-#ifndef HAVE_NANOSLEEP
+    { "HAVE_IPV6", "Support IPv6",
+#ifndef HAVE_IPV6
         0 },
 #else
         1 },
 #endif
-
-#if defined(BEOS_COMPILE) || defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (beos/unix/windows) */
-    { "HAVE_CATWEASELMKIII", "Support for Catweasel MKIII.",
-#ifndef HAVE_CATWEASELMKIII
+/* All? */
+    { "HAVE_LIBCURL", "Use the libcurl library",
+#ifndef HAVE_LIBCURL
         0 },
 #else
         1 },
 #endif
-#endif
-
 #if defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (unix/windows) */
     { "HAVE_LIBIEEE1284", "Enable IEEE1284 library for parallel port", /* (-lieee1284) */
 #ifndef HAVE_LIBIEEE1284
@@ -177,7 +180,21 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 
+/* (all) */
+    { "HAVE_NANOSLEEP", "Use nanosleep instead of usleep",
+#ifndef HAVE_NANOSLEEP
+        0 },
+#else
+        1 },
+#endif
 
+/* (all) */
+    { "HAVE_NETWORK", "Enable netplay support",
+#ifndef HAVE_NETWORK
+        0 },
+#else
+        1 },
+#endif
 
 #if defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (unix/windows) */
     { "HAVE_REALDEVICE", "Support for OpenCBM", /* (former CBM4Linux). */
@@ -187,19 +204,43 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
-
-/* SID related stuff */
-
-/* (all) */
-    { "HAVE_FASTSID", "Enable FASTSID support. (deprecated)",
-#ifndef HAVE_FASTSID
+#if defined(BEOS_COMPILE) || defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (beos/unix/windows) */
+    { "HAVE_PARSID", "Support for ParSID.",
+#ifndef HAVE_PARSID
         0 },
 #else
         1 },
 #endif
+#endif
+
+#if defined(UNIX_COMPILE) /* (unix) */
+    { "HAVE_PORTSID", "Support for file device based access to ParSID.",
+#ifndef HAVE_PORTSID
+        0 },
+#else
+        1 },
+#endif
+#endif
+
 /* (all) */
-    { "HAVE_RESIDFP", "Enable ReSIDfp support.",
-#ifndef HAVE_RESIDFP
+    { "HAVE_USBSID", "Enable USBSID support",
+#ifndef HAVE_USBSID
+        0 },
+#else
+        1 },
+#endif
+
+/* (all) */
+    { "HAVE_PNG", "Use the PNG library.",
+#ifndef HAVE_PNG
+        0 },
+#else
+        1 },
+#endif
+
+/* (all) */
+    { "HAVE_FASTSID", "Enable FASTSID support. (deprecated)",
+#ifndef HAVE_FASTSID
         0 },
 #else
         1 },
@@ -227,49 +268,6 @@ static const feature_list_t featurelist[] = {
 #else
         1 },
 #endif
-
-#if defined(BEOS_COMPILE) || defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (beos/unix/windows) */
-    { "HAVE_HARDSID", "Support for HardSID.",
-#ifndef HAVE_HARDSID
-        0 },
-#else
-        1 },
-#endif
-#endif
-#if defined(BEOS_COMPILE) || defined(UNIX_COMPILE) || defined(WINDOWS_COMPILE) /* (beos/unix/windows) */
-    { "HAVE_PARSID", "Support for ParSID.",
-#ifndef HAVE_PARSID
-        0 },
-#else
-        1 },
-#endif
-#endif
-#if defined(UNIX_COMPILE) /* (unix) */
-    { "HAVE_PORTSID", "Support for file device based access to ParSID.",
-#ifndef HAVE_PORTSID
-        0 },
-#else
-        1 },
-#endif
-#endif
-/* (all) */
-    { "HAVE_USBSID", "Enable USBSID support",
-#ifndef HAVE_USBSID
-        0 },
-#else
-        1 },
-#endif
-
-/* network stuff */
-
-/* (all) */
-    { "HAVE_NETWORK", "Enable netplay support",
-#ifndef HAVE_NETWORK
-        0 },
-#else
-        1 },
-#endif
-
 /* (all) */
     { "HAVE_RS232DEV", "Enable RS232 emulation.",
 #ifndef HAVE_RS232DEV
@@ -284,81 +282,6 @@ static const feature_list_t featurelist[] = {
 #else
         1 },
 #endif
-
-/* All? */
-    { "HAVE_LIBCURL", "Use the libcurl library",
-#ifndef HAVE_LIBCURL
-        0 },
-#else
-        1 },
-#endif
-/* (all) */
-    { "HAVE_IPV6", "Support IPv6",
-#ifndef HAVE_IPV6
-        0 },
-#else
-        1 },
-#endif
-
-/* (all) */
-    { "HAVE_RAWNET", "Enable raw ethernet emulation.",
-#ifndef HAVE_RAWNET
-        0 },
-#else
-        1 },
-#endif
-
-#if defined(UNIX_COMPILE) /* (unix) */
-    { "HAVE_CAPABILITIES", "Support for POSIX 1003.1e capabilities",
-#ifndef HAVE_CAPABILITIES
-        0 },
-#else
-        1 },
-#endif
-#endif
-/* (all) */
-    { "HAVE_PCAP", "Use the PCAP library.",
-#ifndef HAVE_PCAP
-        0 },
-#else
-        1 },
-#endif
-
-#if defined(UNIX_COMPILE) /* (unix) */
-    { "HAVE_LIBNET", "Use the libnet library.",
-#ifndef HAVE_LIBNET
-        0 },
-#else
-        1 },
-#endif
-#endif
-#if !defined(WINDOWS_COMPILE) /* not windows */
-    { "HAVE_TUNTAP", "Support for TUN/TAP virtual network interface.",
-#ifndef HAVE_TUNTAP
-        0 },
-#else
-        1 },
-#endif
-#endif
-
-/* joystick / HID controller backend */
-
-#ifdef MACOS_COMPILE /* (osx) */
-    { "HAS_HIDMGR", "Enable Mac IOHIDManager Joystick driver.",
-#ifndef HAS_HIDMGR
-        0 },
-#else
-        1 },
-#endif
-#endif
-#ifdef WINDOWS_COMPILE /* (windows) */
-    { "HAVE_DINPUT", "Use the DirectInput joystick driver",
-#ifndef HAVE_DINPUT
-        0 },
-#else
-        1 },
-#endif
-#endif
 #if defined(USE_SDLUI) || defined(USE_SDL2UI) /* (sdl) */
     { "HAVE_SDL_NUMJOYSTICKS", "The SDL_NumJoysticks function is available",
 #ifndef HAVE_SDL_NUMJOYSTICKS
@@ -367,10 +290,6 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
-
-/* sound backends */
-
-#if 0 /* not used anywhere except for selecting default driver in sound.s */
 #if defined(UNIX_COMPILE) /* (unix) */
     { "HAVE_SYS_AUDIO_H", "The <sys/audio.h> header file is available.",
 #ifndef HAVE_SYS_AUDIO_H
@@ -387,11 +306,60 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
+/* (all) */
+    { "HAVE_RAWNET", "Enable raw ethernet emulation.",
+#ifndef HAVE_RAWNET
+        0 },
+#else
+        1 },
+#endif
+
+/* (all) */
+    { "HAVE_PCAP", "Use the PCAP library.",
+#ifndef HAVE_PCAP
+        0 },
+#else
+        1 },
 #endif
 
 #if defined(UNIX_COMPILE) /* (unix) */
-    { "USE_OSS", "Enable OSS support.",
-#ifndef USE_OSS
+    { "HAVE_LIBNET", "Use the libnet library.",
+#ifndef HAVE_LIBNET
+        0 },
+#else
+        1 },
+#endif
+#endif
+
+#if !defined(WINDOWS_COMPILE) /* not windows */
+    { "HAVE_TUNTAP", "Support for TUN/TAP virtual network interface.",
+#ifndef HAVE_TUNTAP
+        0 },
+#else
+        1 },
+#endif
+#endif
+
+#if defined(UNIX_COMPILE) /* (unix) */
+    { "HAVE_CAPABILITIES", "Support for POSIX 1003.1e capabilities",
+#ifndef HAVE_CAPABILITIES
+        0 },
+#else
+        1 },
+#endif
+#endif
+/* (all) */
+    { "HAVE_X64_IMAGE", "Support for X64 image files (deprecated)",
+#ifndef HAVE_X64_IMAGE
+      0 },
+#else
+      1 },
+#endif
+
+/* (all) */
+#ifdef UNIX_COMPILE /* (unix) */
+    { "LINUX_JOYSTICK", "Enable support for Linux style joysticks.",
+#ifndef LINUX_JOYSTICK
         0 },
 #else
         1 },
@@ -405,15 +373,6 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
-
-#if defined(MACOS_COMPILE) /* (osx) */
-    { "HAVE_AUDIO_UNIT", "Enable AudioUnit support.",
-#ifndef HAVE_AUDIO_UNIT
-        0 },
-#else
-        1 },
-#endif
-#endif
 #if defined(MACOS_COMPILE) /* (osx) */
     { "USE_COREAUDIO", "Enable CoreAudio support.",
 #ifndef USE_COREAUDIO
@@ -422,7 +381,6 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
-
 #if defined(WINDOWS_COMPILE) /* (windows) */
     { "USE_DXSOUND", "Enable DirectX sound support.",
 #ifndef USE_DXSOUND
@@ -431,34 +389,16 @@ static const feature_list_t featurelist[] = {
         1 },
 #endif
 #endif
-
-/* (all) */
-    { "USE_PORTAUDIO", "Enable portaudio sound input support.",
-#ifndef USE_PORTAUDIO
-        0 },
-#else
-        1 },
-#endif
-/* (all) */
-    { "USE_PULSE", "Enable pulseaudio support.",
-#ifndef USE_PULSE
-        0 },
-#else
-        1 },
-#endif
-/* (all) */
-    { "USE_SDL_AUDIO", "Enable SDL sound support.",
-#ifndef USE_SDL_AUDIO
-        0 },
-#else
-        1 },
-#endif
-
-/* audio encoder */
-
 /* (all) */
     { "USE_LAMEMP3", "Enable lamemp3 encoding support.",
 #ifndef USE_LAMEMP3
+        0 },
+#else
+        1 },
+#endif
+/* (all) */
+    { "USE_PORTAUDIO", "Enable portaudio sound input support.",
+#ifndef USE_PORTAUDIO
         0 },
 #else
         1 },
@@ -484,19 +424,50 @@ static const feature_list_t featurelist[] = {
 #else
         1 },
 #endif
-
-/* image encoder */
-
+#if defined(UNIX_COMPILE) /* (unix) */
+    { "USE_OSS", "Enable OSS support.",
+#ifndef USE_OSS
+        0 },
+#else
+        1 },
+#endif
+#endif
 /* (all) */
-    { "HAVE_GIF", "Use the GIF or UNGIF library",
-#ifndef HAVE_GIF
+    { "USE_PULSE", "Enable pulseaudio support.",
+#ifndef USE_PULSE
         0 },
 #else
         1 },
 #endif
 /* (all) */
-    { "HAVE_PNG", "Use the PNG library.",
-#ifndef HAVE_PNG
+    { "USE_SDL_AUDIO", "Enable SDL sound support.",
+#ifndef USE_SDL_AUDIO
+        0 },
+#else
+        1 },
+#endif
+
+    { "USE_VICE_THREAD", "UI and emu each on different threads.",
+#  ifndef USE_VICE_THREAD
+        0 },
+#  else
+        1 },
+#  endif
+
+/*
+ * Used in Gtk3 for Unix. Gtk3 can also use fontconfig as a backend on MacOS
+ * and Windows.
+ */
+    { "HAVE_FONTCONFIG", "Support dynamic font loading via Fontconfig.",
+#ifndef HAVE_FONTCONFIG
+        0 },
+#else
+        1 },
+#endif
+
+/* Gtk3UI debugging support */
+    { "HAVE_DEBUG_GTK3UI", "Enable debugging messages in the Gtk3 UI.",
+#ifndef HAVE_DEBUG_GTK3UI
         0 },
 #else
         1 },


### PR DESCRIPTION
Reverts PR #9 so the fork's main branch content returns to its pre-sync state. Upstream sync work belongs on macos/native-metal and mcp-server only.