### PR TITLE
brand(WAL-19): normalize product name to 'VICE Mac'

### DIFF
--- a/MacVICEKit/Sources/MacVICEKit/MacVICEKit.docc/MacVICEKit.md
+++ b/MacVICEKit/Sources/MacVICEKit/MacVICEKit.docc/MacVICEKit.md
@@ -8,7 +8,7 @@ Embed VICE machines in native macOS apps.
 
 ## Overview
 
-MacVICEKit is the Swift package behind mac VICE. It wraps the native VICE core
+MacVICEKit is the Swift package behind VICE Mac. It wraps the native VICE core
 with APIs for starting emulator sessions, embedding a Metal display, forwarding
 Mac input, attaching media, observing emulator callbacks, and building debugger
 or inspection tools.
@@ -56,7 +56,7 @@ struct EmulatorView: View {
 MacVICEKit does not build VICE during Swift package resolution. Apps should use
 the release SDK or provide a prepared runtime directory. With
 ``MacVICERuntimeLocation/automatic``, runtime lookup checks `MACVICE_RUNTIME_DIR`,
-embedded framework layouts, app bundle `Frameworks`, and local mac VICE checkout
+embedded framework layouts, app bundle `Frameworks`, and local VICE Mac checkout
 builds.
 
 The runtime must contain the machine-specific `libvicemac*.dylib` files and the

--- a/commodore-utils/geos-rtc/README.md
+++ b/commodore-utils/geos-rtc/README.md
@@ -1,4 +1,4 @@
-# mac VICE GEOS RTC
+# VICE Mac GEOS RTC
 
 Tiny GEOS auto-exec drivers for the VICE userport DS1307 real-time clock.
 
@@ -14,4 +14,4 @@ Outputs land in `build/`:
 - `macvice-rtc128.prg`
 - matching `.grc` metadata files
 
-Package either PRG with the mac VICE disk editor's GEOS Package Assistant, or install it directly onto a GEOS disk image from the assistant. The driver expects VICE's DS1307 userport RTC device to be enabled before GEOS boots.
+Package either PRG with the VICE Mac disk editor's GEOS Package Assistant, or install it directly onto a GEOS disk image from the assistant. The driver expects VICE's DS1307 userport RTC device to be enabled before GEOS boots.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
-# mac VICE Kubernetes Deployment
+# VICE Mac Kubernetes Deployment
 
-These manifests publish the static mac VICE website at:
+These manifests publish the static VICE Mac website at:
 
 - `http://macvice.com`
 - `http://www.macvice.com`

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# mac VICE Website
+# VICE Mac Website
 
-Static marketing site for mac VICE.
+Static marketing site for VICE Mac.
 
 Open `index.html` directly in a browser, or serve the `website/` directory from
 any static host. There is no build step.

--- a/website/index.html
+++ b/website/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>mac VICE - Native Commodore emulation for macOS</title>
+    <title>VICE Mac - Native Commodore emulation for macOS</title>
     <meta
       name="description"
-      content="mac VICE packages the VICE emulator as native Apple Silicon Mac apps with Metal display output, media library, disk tools, controller setup, Q-Link Reloaded setup, and signed DMG releases."
+      content="VICE Mac packages the VICE emulator as native Apple Silicon Mac apps with Metal display output, media library, disk tools, controller setup, Q-Link Reloaded setup, and signed DMG releases."
     >
-    <meta property="og:title" content="mac VICE">
+    <meta property="og:title" content="VICE Mac">
     <meta property="og:description" content="VICE emulator apps for Apple Silicon Macs.">
     <meta property="og:type" content="website">
     <meta property="og:image" content="assets/mac-vice-icon.png">
@@ -18,9 +18,9 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="#top" aria-label="mac VICE home">
+      <a class="brand" href="#top" aria-label="VICE Mac home">
         <img src="assets/mac-vice-icon.png" width="36" height="36" alt="">
-        <span>mac VICE</span>
+        <span>VICE Mac</span>
       </a>
       <nav class="site-nav" aria-label="Primary">
         <a href="#features">Features</a>
@@ -36,7 +36,7 @@
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
           <p class="eyebrow">VICE, packaged for macOS</p>
-          <h1 id="hero-title">mac VICE</h1>
+          <h1 id="hero-title">VICE Mac</h1>
           <p class="hero-subtitle">
             Current VICE, packaged for Apple Silicon Macs with Metal display
             output, Mac settings, media tools, controller setup, Q-Link
@@ -55,13 +55,13 @@
           </p>
         </div>
 
-        <div class="hero-stage" aria-label="mac VICE app preview">
+        <div class="hero-stage" aria-label="VICE Mac app preview">
           <figure class="hero-shot">
             <img
               src="assets/screenshots/x64sc-hvsc.png"
               width="1800"
               height="930"
-              alt="x64sc running the HVSC intro disk in a native mac VICE window"
+              alt="x64sc running the HVSC intro disk in a native VICE Mac window"
             >
             <figcaption>x64sc running the HVSC intro disk.</figcaption>
           </figure>
@@ -243,7 +243,7 @@
               width="1400"
               height="1091"
               loading="lazy"
-              alt="Machine settings in a native mac VICE settings window"
+              alt="Machine settings in a native VICE Mac settings window"
             >
             <div class="caption">
               <h3>Machine settings</h3>
@@ -258,7 +258,7 @@
               width="1400"
               height="1091"
               loading="lazy"
-              alt="Display settings for video filter profiles in mac VICE"
+              alt="Display settings for video filter profiles in VICE Mac"
             >
             <div class="caption">
               <h3>Display profiles</h3>
@@ -337,14 +337,14 @@
             >
             <div class="caption">
               <p class="machine-name">Online</p>
-              <h3>Q-Link Reloaded, launched from mac VICE.</h3>
+              <h3>Q-Link Reloaded, launched from VICE Mac.</h3>
               <p>Known disk versions get copied, patched, checked, and started from one native command.</p>
             </div>
           </article>
 
           <div class="qlink-copy">
             <p>
-              Choose a Quantum Link D64 you already own and mac VICE copies it
+              Choose a Quantum Link D64 you already own and VICE Mac copies it
               into the media library, fingerprints the known disk version, and
               patches only that managed copy for Q-Link Reloaded.
             </p>
@@ -359,7 +359,7 @@
               <li>Original disk image stays untouched.</li>
               <li>Unknown Q-Link disks are rejected instead of guessed.</li>
               <li>Required modem and writable drive settings are checked before launch.</li>
-              <li>If existing settings conflict, mac VICE asks before changing anything.</li>
+              <li>If existing settings conflict, VICE Mac asks before changing anything.</li>
             </ul>
           </div>
         </div>
@@ -395,24 +395,24 @@
       <section class="notices-section" id="notices" aria-labelledby="notices-title">
         <div class="notices-heading">
           <p class="eyebrow">Credits and notices</p>
-          <h2 id="notices-title">mac VICE builds on decades of work.</h2>
+          <h2 id="notices-title">VICE Mac builds on decades of work.</h2>
         </div>
         <div class="notices-copy">
           <p>
-            Original mac VICE website, macOS integration, packaging, and native
+            Original VICE Mac website, macOS integration, packaging, and native
             UI work © 2026 Barry Walker and contributors, licensed under the
             GNU GPL version 2 or later.
           </p>
           <p>
             VICE, the Versatile Commodore Emulator, is the work of the VICE
             Team and contributors and is distributed under the GNU General
-            Public License, version 2 or later. mac VICE exists because of that
+            Public License, version 2 or later. VICE Mac exists because of that
             project.
           </p>
           <p>
             Commodore is an active company and brand. Commodore, Quantum Link,
             Q-Link, and other product or service names are names or marks of
-            their respective owners. mac VICE is not affiliated with those
+            their respective owners. VICE Mac is not affiliated with those
             owners.
           </p>
           <div class="notices-links" aria-label="Notice links">
@@ -426,7 +426,7 @@
     </main>
 
     <footer class="site-footer">
-      <span>© 2026 Barry Walker for original mac VICE work. GPL-2.0-or-later. Built on VICE.</span>
+      <span>© 2026 Barry Walker for original VICE Mac work. GPL-2.0-or-later. Built on VICE.</span>
       <div class="footer-links">
         <a href="#notices">Notices</a>
         <a href="https://github.com/barryw/vice-macos/blob/main/LICENSE">License</a>

--- a/website/macvicekit.html
+++ b/website/macvicekit.html
@@ -6,7 +6,7 @@
     <title>MacVICEKit - Embed VICE in Mac apps</title>
     <meta
       name="description"
-      content="MacVICEKit is the Swift package behind mac VICE, giving macOS developers a native way to embed the VICE core, Metal display output, media helpers, input routing, and debugger APIs."
+      content="MacVICEKit is the Swift package behind VICE Mac, giving macOS developers a native way to embed the VICE core, Metal display output, media helpers, input routing, and debugger APIs."
     >
     <meta property="og:title" content="MacVICEKit">
     <meta property="og:description" content="Embed the VICE core in native macOS apps.">
@@ -18,9 +18,9 @@
   </head>
   <body class="kit-page">
     <header class="site-header">
-      <a class="brand" href="index.html#top" aria-label="mac VICE home">
+      <a class="brand" href="index.html#top" aria-label="VICE Mac home">
         <img src="assets/mac-vice-icon.png" width="36" height="36" alt="">
-        <span>mac VICE</span>
+        <span>VICE Mac</span>
       </a>
       <nav class="site-nav" aria-label="Primary">
         <a href="index.html#features">Features</a>
@@ -129,7 +129,7 @@
           </article>
           <article class="feature-card">
             <h3>Metal display</h3>
-            <p>Embed a native display view with the same rendering path used by mac VICE.</p>
+            <p>Embed a native display view with the same rendering path used by VICE Mac.</p>
           </article>
           <article class="feature-card">
             <h3>Media helpers</h3>
@@ -260,7 +260,7 @@ struct EmulatorView: View {
     </main>
 
     <footer class="site-footer">
-      <span>© 2026 Barry Walker for original mac VICE work. GPL-2.0-or-later. Built on VICE.</span>
+      <span>© 2026 Barry Walker for original VICE Mac work. GPL-2.0-or-later. Built on VICE.</span>
       <div class="footer-links">
         <a href="index.html#notices">Notices</a>
         <a href="https://github.com/barryw/vice-macos/blob/main/LICENSE">License</a>


### PR DESCRIPTION
Part of **WAL-19** (brand naming/casing normalization across the suite), executed by Atlas (VP Eng) per the ratified WAL-16 `brand-guidelines` §3 (decision #3).

## What
Normalize the product name to the canonical **VICE Mac**; drop the `mac VICE` variant across marketing/site/docs copy.

Files: `website/index.html`, `website/macvicekit.html`, `website/README.md`, `commodore-utils/geos-rtc/README.md`, `k8s/README.md`, `MacVICEKit.docc/MacVICEKit.md`.

## Scope / safety
- Copy-only. **No functional code.** The `MacVICEKit` Swift package symbol (and all `MacVICE*` API names) are unchanged — only the spaced brand label `mac VICE` was touched.
- Intentionally left: GEOS `.grc` source `author` strings (functional source) and the generated DocC `*.json` (build artifact — regenerates from the `.docc` source already fixed here).
- Upstream VICE attribution and GPL-2.0-or-later posture unchanged.

## Deferred (not in this PR)
The 'a Walker Heavy Industries project' endorsement + 'Part of the suite' cross-link block are gated on the WAL-18 house-hub URL and will land as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)