### PR TITLE
brand(WAL-40): WHI endorsement + suite cross-link block

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">VICE Mac</h1>
 
+_**VICE Mac** is a Walker Heavy Industries project._
+
 <p align="center">
   <strong>VICE underneath. Native Mac on top.</strong><br>
   Apple Silicon Commodore emulation with SwiftUI, Metal, signed releases, a real media library, Q-Link Reloaded support, and MacVICEKit for developers.
@@ -291,3 +293,11 @@ explicitly states otherwise.
 VICE Mac exists because the VICE team did the hard emulator work first. This
 project adds the native macOS application layer, packaging, MacVICEKit, website,
 and Mac-specific workflow on top of that foundation.
+
+## Part of the suite
+
+VICE Mac is part of the **Walker Heavy Industries** retro toolchain —
+modern tools for the retro 8- and 16-bit ecosystem.
+
+- **House hub:** https://whi.dev
+- **Siblings:** VICE Mac · VICE MCP · FamiForge · NESBasic · Novus · Miggy Draw · NovaVM


### PR DESCRIPTION
Adds the ratified **Walker Heavy Industries** endorsement + `## Part of the suite` cross-link block to the README, per WAL-19 `brand-normalization-spec` §2/§6.

- Endorsement under the title: *"<Product> is a Walker Heavy Industries project."*
- Suite cross-link block: house hub **https://whi.dev** + the 7-product sibling roster.

House-hub URL (`https://whi.dev`) ratified by the CEO on **WAL-40** (confirmation accepted). Copy-only, no functional/code changes.