### PR TITLE
k8s: resilient website deploy — rolling strategy + PDB (ADR 0007, WAL-108)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -11,6 +11,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: macvice-website
       app.kubernetes.io/component: website
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: macvice-website
+  namespace: macvice
+  labels:
+    app.kubernetes.io/name: macvice-website
+    app.kubernetes.io/component: website
+spec:
+  # Keep at least one pod serving during voluntary disruptions (node drain,
+  # cluster upgrade). Paired with replicas: 2 this guarantees the site stays
+  # up while a node is cordoned/drained. (ADR 0007 / WAL-108)
+  #
+  # NOT referenced by k8s/kustomization.yaml yet: the namespace-scoped CI SA
+  # cannot create/patch PDBs until the RBAC grant in WAL-107 lands. Apply
+  # out-of-band: kubectl apply -f k8s/pdb.yaml
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: macvice-website
+      app.kubernetes.io/component: website


### PR DESCRIPTION
Brings the macvice.com marketing site up to the ADR 0007 resilience standard — see WAL-108.

Changes (`k8s/`):
1. **Explicit rolling strategy** `RollingUpdate` with `maxUnavailable: 0`, `maxSurge: 1` — old pods keep serving until the new one passes readiness (previously unset, so k8s default 25%/25% could briefly drop capacity).
2. **PodDisruptionBudget** (`k8s/pdb.yaml`, `minAvailable: 1`) — at least one pod stays up during node drain / upgrade.

Already compliant: `replicas: 2`, `namespace.yaml` already dropped from CI kustomize resources, readiness+liveness probes present (on `/healthz`, port `http` — this site's health path; left unchanged).

`pdb.yaml` is intentionally **not** referenced in `k8s/kustomization.yaml` yet: the namespace-scoped CI SA cannot create/patch PDBs until the RBAC grant in WAL-107 (Keel) lands. Applied out-of-band initially.

Ref: whi-brand `docs/decisions/0007-resilient-static-site-deploys.md`, Novus `deploy/` (reference).

Co-Authored-By: Paperclip <noreply@paperclip.ing>