### PR TITLE
ci(website): fix pipeline compile error on website/k8s pushes (WAL-141)

### DIFF
--- a/.woodpecker/website.yaml
+++ b/.woodpecker/website.yaml
@@ -31,25 +31,6 @@ steps:
       - bash website/tools/validate-containerfile-pages.sh
       - node --check website/site.js
 
-  - name: wait-for-release
-    image: node:22-bookworm
-    environment:
-      GH_TOKEN:
-        from_secret: github_token
-      VICE_MAC_WEBSITE_WAIT_FOR_RELEASE: "1"
-    commands:
-      - bash -n website/tools/wait-for-current-release.sh
-      - bash website/tools/wait-for-current-release.sh
-    when:
-      - event: push
-        evaluate: 'CI_COMMIT_BRANCH == "main"'
-        path:
-          exclude:
-            - website/**
-            - k8s/**
-            - .woodpecker/metal-ui.yaml
-            - .woodpecker/website.yaml
-
   - name: validate-k8s
     image: bitnami/kubectl:latest
     commands:
@@ -63,7 +44,6 @@ steps:
     depends_on:
       - validate-static
       - validate-k8s
-      - wait-for-release
     environment:
       GHCR_TOKEN:
         from_secret: github_token


### PR DESCRIPTION
## WAL-141 — vice-macos build failing

### Root cause
Every push touching `website/**` or `k8s/**` failed to compile the Woodpecker pipeline:

```
step 'build-and-push' depends on unknown step 'wait-for-release'
```

`build-and-push` hard-depended on `wait-for-release`, but that step carried a path-exclude `when:` clause that removed it from the DAG on exactly those pushes → dangling dependency → whole pipeline (both `metal-ui` release + `website` workflows) marked `error`. Confirmed on live pipelines #190 and #191.

### Fix
Remove the `wait-for-release` step and its dependency.

The step gated the site rebuild on a matching GitHub release, but the site does **not** bake release data at build time — `website/site.js` fetches the latest release from `api.github.com` at **runtime in the browser** (`fetch(apiUrl)`). So the wait offered no build-time correctness and only risked 2h hangs/timeouts. The DAG (`validate-static`,`validate-k8s` → `build-and-push` → `deploy`) now validates on every trigger path.

### Verification
- Local DAG check: all `depends_on` resolve; no residual `wait-for-release` references.
- Release pipeline `metal-ui.yaml` untouched and healthy.
- Post-merge: push to main will run the website workflow green (will monitor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)