### PR TITLE
WAL-163: macvice overlay preStop drain (de-ArgoCD prereq)

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -24,6 +24,13 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      # Drain grace on voluntary disruption / rollout: give Traefik time to stop
+      # routing to a terminating pod, then quit nginx gracefully. Matches the
+      # ArgoCD-managed manifest this overlay is taking over from (WAL-163
+      # de-ArgoCD cutover) so the single-owner CI deploy preserves ADR-0007
+      # item 8 (never-down) — without it the cutover would regress to ~1.4% 502
+      # on rollout. (ADR 0007 / WAL-148)
+      terminationGracePeriodSeconds: 35
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -32,6 +39,10 @@ spec:
         - name: website
           image: ghcr.io/barryw/macvice-website:latest
           imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 8; nginx -s quit"]
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## What

Adds `lifecycle.preStop` (`sleep 8; nginx -s quit`) + `terminationGracePeriodSeconds: 35` to the `deploy/` CI overlay for macvice-website.

## Why

Phase 1 of the macvice de-ArgoCD cutover (WAL-163, child of WAL-161 Option C, Atlas-approved). macvice is currently **dual-owned**: ArgoCD syncs `kubernetes/macvice/resources.yaml` (pinned image, WITH preStop) while repo CI deploys `release-static-site` -> `deploy/` (`:latest`, WAS missing preStop).

Removing the ArgoCD dir (Phase 2, infra PR) hands the site to CI as sole owner. Without this change the next CI deploy would drop the graceful drain and regress ADR-0007 item 8 (never-down) to ~1.4% 502 on rollout.

This makes the overlay's pod spec match the live ArgoCD-managed manifest, so the ownership handoff is a no-op on drain behavior.

## Verify

- `kubectl kustomize deploy/` renders preStop + grace35 + replicas 2 ✅
- Merge triggers the release-static-site pipeline (WP repo 45); verify green + macvice.com 200 before infra removal.